### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   Scan-Build:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/45](https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/45)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
1. The `actions/checkout@v4` step requires `contents: read` to fetch the repository code.
2. The `ShiftLeftSecurity/scan-action@master` step uses the `GITHUB_TOKEN`, but no additional permissions are explicitly required for scanning.
3. The `github/codeql-action/upload-sarif@v3` step uploads SARIF files, which does not require write permissions to the repository.

Thus, the minimal permissions required are `contents: read`. We will add this to the root of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
