### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,4 +1,7 @@
 name: Update License
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/47](https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/47)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are needed:
- `contents: write` for updating the license file and committing changes.
- `pull-requests: write` for creating and merging pull requests.

The `permissions` block will be added after the `name` field to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
