### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/48](https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/48)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with pull requests and uses the `GITHUB_TOKEN`, we can set `contents: read` and `pull-requests: write` permissions. These permissions allow the workflow to read repository contents and manage pull requests without granting unnecessary access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
