### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/49](https://github.com/LanikSJ/docker-php-alpine/security/code-scanning/49)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are likely needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

This change will ensure that the workflow has only the necessary permissions, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
